### PR TITLE
update signed message

### DIFF
--- a/contracts/claim/assembly/Claim.ts
+++ b/contracts/claim/assembly/Claim.ts
@@ -36,8 +36,9 @@ export class Claim {
     const ethAddr    = Arrays.toHexString(eth_address);
     const koinosAddr = Base58.encode(koin_address);
     const message    = `claim koins ${ethAddr}:${koinosAddr}`;
+    const signedMessage = `\x19Ethereum Signed Message:\n${message.length}${message}`;
 
-    let multihashBytes = System.hash(Crypto.multicodec.keccak_256, StringBytes.stringToBytes(message));
+    let multihashBytes = System.hash(Crypto.multicodec.keccak_256, StringBytes.stringToBytes(signedMessage));
     const pubKey       = System.recoverPublicKey(signature, multihashBytes!, chain.dsa.ecdsa_secp256k1, false);
 
     multihashBytes = System.hash(Crypto.multicodec.keccak_256, pubKey!.subarray(1));


### PR DESCRIPTION
For security reasons, the ethereum wallets add always a prefix in the message to sign:
```
sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)))
```
then we have to take into account this prefix in the claim contract.

References:
https://docs.metamask.io/guide/signing-data.html
https://programtheblockchain.com/posts/2018/02/17/signing-and-verifying-messages-in-ethereum/ https://blog.ricmoo.com/verifying-messages-in-solidity-50a94f82b2ca

Resolves <!-- Issue number(s) in the form #1 or org/repo#1 -->

## Brief description
<!-- Add a brief summary of the code changes in the pull request -->

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
