### PR TITLE
Standardize event names

### DIFF
--- a/contracts/claim/assembly/Claim.ts
+++ b/contracts/claim/assembly/Claim.ts
@@ -35,7 +35,7 @@ export class Claim {
     // Verify the signature in the second slot against the given address
     const ethAddr    = Arrays.toHexString(eth_address);
     const koinosAddr = Base58.encode(koin_address);
-    const message    = `claim tkoins ${ethAddr}:${koinosAddr}`;
+    const message    = BUILD_FOR_TESTING ? `claim tkoins ${ethAddr}:${koinosAddr}` : `claim koins ${ethAddr}:${koinosAddr}`;
     const signedMessage = `\x19Ethereum Signed Message:\n${message.length}${message}`;
 
     let multihashBytes = System.hash(Crypto.multicodec.keccak_256, StringBytes.stringToBytes(signedMessage));

--- a/contracts/claim_delegation/assembly/ClaimDelegation.ts
+++ b/contracts/claim_delegation/assembly/ClaimDelegation.ts
@@ -1,7 +1,7 @@
 import { authority, Base58, Crypto, Protobuf, error, System, StringBytes, claim, value, Arrays } from "@koinos/sdk-as";
 import { protocol } from "@koinos/proto-as";
 
-export class Claim {
+export class ClaimDelegation {
   private _claim_contract_id: Uint8Array;
   private _claim_entry: u32 = 0xdd1b3c31;
   private _check_claim_entry: u32 = 0x2ac66b4c;

--- a/contracts/claim_delegation/assembly/index.ts
+++ b/contracts/claim_delegation/assembly/index.ts
@@ -1,5 +1,5 @@
 import { System, Protobuf, authority } from "@koinos/sdk-as";
-import { Claim as ContractClass } from "./ClaimDelegation";
+import { ClaimDelegation as ContractClass } from "./ClaimDelegation";
 
 export function main(): i32 {
   const contractArgs = System.getArguments();

--- a/contracts/governance/assembly/Governance.ts
+++ b/contracts/governance/assembly/Governance.ts
@@ -205,7 +205,7 @@ export class Governance {
     event.id = args.operation_merkle_root;
     event.status = governance.proposal_status.pending;
 
-    System.event('proposal.submission', Protobuf.encode(event, governance.proposal_status_event.encode), []);
+    System.event('koinos.contracts.governance.proposal_status_event', Protobuf.encode(event, governance.proposal_status_event.encode), []);
 
     return new governance.submit_proposal_result();
   }
@@ -252,7 +252,7 @@ export class Governance {
     event.id = id;
     event.status = prec.status;
 
-    System.event('proposal.status', Protobuf.encode(event, governance.proposal_status_event.encode), []);
+    System.event('koinos.contracts.governance.proposal_status_event', Protobuf.encode(event, governance.proposal_status_event.encode), []);
   }
 
   handle_active_proposal(prec: governance.proposal_record, height: u64): void {
@@ -274,7 +274,7 @@ export class Governance {
     event.id = id;
     event.status = prec.status;
 
-    System.event('proposal.status', Protobuf.encode(event, governance.proposal_status_event.encode), []);
+    System.event('koinos.contracts.governance.proposal_status_event', Protobuf.encode(event, governance.proposal_status_event.encode), []);
   }
 
   handle_approved_proposal(prec: governance.proposal_record, height: u64): void {
@@ -318,7 +318,7 @@ export class Governance {
     event.id = id;
     event.status = prec.status;
 
-    System.event('proposal.status', Protobuf.encode(event, governance.proposal_status_event.encode), []);
+    System.event('koinos.contracts.governance.proposal_status_event', Protobuf.encode(event, governance.proposal_status_event.encode), []);
 
     System.removeObject(State.Space.Proposal(), id);
   }
@@ -362,7 +362,7 @@ export class Governance {
       event.vote_tally = current_vote_tally;
       event.vote_threshold = prec.vote_threshold;
 
-      System.event('proposal.vote', Protobuf.encode(event, governance.proposal_vote_event.encode), []);
+      System.event('koinos.contracts.governance.proposal_vote_event', Protobuf.encode(event, governance.proposal_vote_event.encode), []);
     }
   }
 

--- a/contracts/pob/assembly/Pob.ts
+++ b/contracts/pob/assembly/Pob.ts
@@ -128,7 +128,7 @@ export class Pob {
 
     // Emit an event
     const event = new pob.register_public_key_event(args.producer!, args.public_key);
-    System.event('pob.register_public_key', Protobuf.encode(event, pob.register_public_key_event.encode), [args.producer!]);
+    System.event('koinos.contracts.pob.register_public_key_event', Protobuf.encode(event, pob.register_public_key_event.encode), [args.producer!]);
 
     return new pob.register_public_key_result();
   }

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -239,7 +239,7 @@ export class Vhp {
     impacted.push(args.to!);
     impacted.push(args.from!);
 
-    System.event('vhp.transfer', Protobuf.encode(event, token.transfer_event.encode), impacted);
+    System.event('koinos.contracts.token.transfer_event', Protobuf.encode(event, token.transfer_event.encode), impacted);
 
     return new token.transfer_result();
   }
@@ -286,7 +286,7 @@ export class Vhp {
     let impacted: Uint8Array[] = [];
     impacted.push(args.to!);
 
-    System.event('vhp.mint', Protobuf.encode(event, token.mint_event.encode), impacted);
+    System.event('koinos.contracts.token.mint_event', Protobuf.encode(event, token.mint_event.encode), impacted);
 
     return new token.mint_result();
   }
@@ -332,7 +332,7 @@ export class Vhp {
     let impacted: Uint8Array[] = [];
     impacted.push(args.from!);
 
-    System.event('vhp.burn', Protobuf.encode(event, token.burn_event.encode), impacted);
+    System.event('koinos.contracts.token.burn_event', Protobuf.encode(event, token.burn_event.encode), impacted);
 
     return new token.burn_result();
   }

--- a/contracts/vhp/assembly/__tests__/vhp.spec.ts
+++ b/contracts/vhp/assembly/__tests__/vhp.spec.ts
@@ -84,10 +84,10 @@ describe("vhp", () => {
     // check events
     const events = MockVM.getEvents();
     expect(events.length).toBe(2);
-    expect(events[0].name).toBe('vhp.mint');
+    expect(events[0].name).toBe('koinos.contracts.token.mint_event');
     expect(events[0].impacted.length).toBe(1);
     expect(Arrays.equal(events[0].impacted[0], MOCK_ACCT1)).toBe(true);
-    expect(events[1].name).toBe('vhp.burn');
+    expect(events[1].name).toBe('koinos.contracts.token.burn_event');
     expect(events[1].impacted.length).toBe(1);
     expect(Arrays.equal(events[1].impacted[0], MOCK_ACCT1)).toBe(true);
 
@@ -167,7 +167,7 @@ describe("vhp", () => {
     // check events
     const events = MockVM.getEvents();
     expect(events.length).toBe(1);
-    expect(events[0].name).toBe('vhp.mint');
+    expect(events[0].name).toBe('koinos.contracts.token.mint_event');
     expect(events[0].impacted.length).toBe(1);
     expect(Arrays.equal(events[0].impacted[0], MOCK_ACCT1)).toBe(true);
 
@@ -290,7 +290,7 @@ describe("vhp", () => {
     const events = MockVM.getEvents();
     // 2 events, 1st one is the mint event, the second one is the transfer event
     expect(events.length).toBe(2);
-    expect(events[1].name).toBe('vhp.transfer');
+    expect(events[1].name).toBe('koinos.contracts.token.transfer_event');
     expect(events[1].impacted.length).toBe(2);
     expect(Arrays.equal(events[1].impacted[0], MOCK_ACCT2)).toBe(true);
     expect(Arrays.equal(events[1].impacted[1], MOCK_ACCT1)).toBe(true);
@@ -581,7 +581,7 @@ describe("vhp", () => {
     const events = MockVM.getEvents();
     // 2 events, 1st one is the mint event, the second one is the transfer event
     expect(events.length).toBe(2);
-    expect(events[1].name).toBe('vhp.transfer');
+    expect(events[1].name).toBe('koinos.contracts.token.transfer_event');
     expect(events[1].impacted.length).toBe(2);
     expect(Arrays.equal(events[1].impacted[0], MOCK_ACCT2)).toBe(true);
     expect(Arrays.equal(events[1].impacted[1], MOCK_ACCT1)).toBe(true);


### PR DESCRIPTION

Related to koinos/koinos-contracts-cpp#79.

## Brief description
Event names will be standardize to their fully qualified protobuf message name.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

