### PR TITLE
Pass arguments to checkAuthority for transfer and burn entry points

### DIFF
--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -68,6 +68,11 @@ namespace State {
 }
 
 export class Vhp {
+  private _arguments: Uint8Array = new Uint8Array(0);
+
+  constructor(args: Uint8Array) {
+    this._arguments = args;
+  }
 
   name(args?: token.name_arguments): token.name_result {
     let result = new token.name_result();
@@ -202,7 +207,7 @@ export class Vhp {
 
     let callerData = System.getCaller();
     System.require(
-      Arrays.equal(callerData.caller, args.from) || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
+      Arrays.equal(callerData.caller, args.from) || System.checkAuthority(authority.authorization_type.contract_call, args.from!, this._arguments),
       'from has not authorized transfer',
       error.error_code.authorization_failure
     );
@@ -296,7 +301,7 @@ export class Vhp {
 
     let callerData = System.getCaller();
     System.require(
-      callerData.caller_privilege == chain.privilege.kernel_mode || callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
+      callerData.caller_privilege == chain.privilege.kernel_mode || callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!, this._arguments),
       'from has not authorized burn',
       error.error_code.authorization_failure
     );

--- a/contracts/vhp/assembly/__tests__/vhp.spec.ts
+++ b/contracts/vhp/assembly/__tests__/vhp.spec.ts
@@ -21,7 +21,7 @@ describe("vhp", () => {
   });
 
   it("should get the name", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     const args = new token.name_arguments();
     const res = tkn.name(args);
@@ -30,7 +30,7 @@ describe("vhp", () => {
   });
 
   it("should get the symbol", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     const args = new token.symbol_arguments();
     const res = tkn.symbol(args);
@@ -39,7 +39,7 @@ describe("vhp", () => {
   });
 
   it("should get the decimals", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     const args = new token.decimals_arguments();
     const res = tkn.decimals(args);
@@ -48,7 +48,7 @@ describe("vhp", () => {
   });
 
   it("should/not burn tokens", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     let callerData = new chain.caller_data();
     callerData.caller = CONTRACT_ID;
@@ -109,7 +109,7 @@ describe("vhp", () => {
 
     // does not burn tokens
     expect(() => {
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const burnArgs = new token.burn_arguments(MOCK_ACCT1, 200);
       tkn.burn(burnArgs);
     }).toThrow();
@@ -127,7 +127,7 @@ describe("vhp", () => {
 
     expect(() => {
       // try to burn tokens
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const burnArgs = new token.burn_arguments(MOCK_ACCT1, 123);
       tkn.burn(burnArgs);
     }).toThrow();
@@ -146,7 +146,7 @@ describe("vhp", () => {
   });
 
   it("should mint tokens", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -186,7 +186,7 @@ describe("vhp", () => {
   });
 
   it("should not mint tokens if not contract account", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set contract_call authority for MOCK_ACCT1 to true so that we cannot mint tokens
     const auth = new MockVM.MockAuthority(authority.authorization_type.contract_call, MOCK_ACCT1, true);
@@ -207,7 +207,7 @@ describe("vhp", () => {
 
     expect(() => {
       // try to mint tokens
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const mintArgs = new token.mint_arguments(MOCK_ACCT2, 123);
       tkn.mint(mintArgs);
     }).toThrow();
@@ -222,7 +222,7 @@ describe("vhp", () => {
   });
 
   it("should not mint tokens if new total supply overflows", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -243,7 +243,7 @@ describe("vhp", () => {
     MockVM.commitTransaction();
 
     expect(() => {
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const mintArgs = new token.mint_arguments(MOCK_ACCT2, u64.MAX_VALUE);
       tkn.mint(mintArgs);
     }).toThrow();
@@ -257,7 +257,7 @@ describe("vhp", () => {
   });
 
   it("should transfer tokens", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -302,7 +302,7 @@ describe("vhp", () => {
   });
 
   it("should not transfer tokens without the proper authorizations", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -321,7 +321,7 @@ describe("vhp", () => {
 
     expect(() => {
       // try to transfer tokens without the proper authorizations for MOCK_ACCT1
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const transferArgs = new token.transfer_arguments(MOCK_ACCT1, MOCK_ACCT2, 10);
       tkn.transfer(transferArgs);
     }).toThrow();
@@ -337,7 +337,7 @@ describe("vhp", () => {
   });
 
   it("should not transfer tokens to self", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -358,7 +358,7 @@ describe("vhp", () => {
 
     // try to transfer tokens
     expect(() => {
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const transferArgs = new token.transfer_arguments(MOCK_ACCT1, MOCK_ACCT1, 10);
       tkn.transfer(transferArgs);
     }).toThrow();
@@ -373,7 +373,7 @@ describe("vhp", () => {
   });
 
   it("should not transfer if insufficient balance", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -394,7 +394,7 @@ describe("vhp", () => {
 
     // try to transfer tokens
     expect(() => {
-      const tkn = new Vhp();
+      const tkn = new Vhp(new Uint8Array(0));
       const transferArgs = new token.transfer_arguments(MOCK_ACCT1, MOCK_ACCT2, 456);
       tkn.transfer(transferArgs);
     }).toThrow();
@@ -409,7 +409,7 @@ describe("vhp", () => {
   });
 
   it("should delay effective balance", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
@@ -547,7 +547,7 @@ describe("vhp", () => {
   });
 
   it("should transfer tokens without authority", () => {
-    const tkn = new Vhp();
+    const tkn = new Vhp(new Uint8Array(0));
 
     // set kernel mode
     MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));

--- a/contracts/vhp/assembly/index.ts
+++ b/contracts/vhp/assembly/index.ts
@@ -5,7 +5,7 @@ export function main(): i32 {
   const contractArgs = System.getArguments();
   let retbuf = new Uint8Array(1024);
 
-  const c = new ContractClass();
+  const c = new ContractClass(contractArgs.args);
 
   switch (contractArgs.entry_point) {
     case 0x82a3537f: {


### PR DESCRIPTION
Resolves #85.

## Brief description
Pass the arguments to `checkAuthority` for both `transfer` and `burn`.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```console
❯ yarn test
yarn run v1.22.19
$ koinos-sdk-as-cli run-tests
Running tests...
yarn asp --verbose --config as-pect.config.js
$ /Users/sgerbino/Projects/koinos-contracts-as/contracts/vhp/node_modules/.bin/asp --verbose --config as-pect.config.js
       ___   _____                       __
      /   | / ___/      ____  ___  _____/ /_
     / /| | \__ \______/ __ \/ _ \/ ___/ __/
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_
   /_/  |_/____/     / .___/\___/\___/\__/
                    /_/

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 355.078ms.
[Log] Using configuration /Users/sgerbino/Projects/koinos-contracts-as/contracts/vhp/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: assembly/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental -u BUILD_FOR_TESTING=1 --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/sgerbino/Projects/koinos-contracts-as/contracts/vhp/node_modules/@as-covers/transform/lib/index.js,/Users/sgerbino/Projects/koinos-contracts-as/contracts/vhp/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: vhp

 [Success]: ✔ should get the name RTrace: +18
 [Success]: ✔ should get the symbol RTrace: +18
 [Success]: ✔ should get the decimals RTrace: +14
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] koinos.contracts.token.burn_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EAo=
[Contract Exit] account 'from' has insufficient balance
[Contract Exit] from has not authorized burn
 [Success]: ✔ should/not burn tokens RTrace: +631
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
 [Success]: ✔ should mint tokens RTrace: +234
[Contract Exit] account '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' authorization failed
 [Success]: ✔ should not mint tokens if not contract account RTrace: +196
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6EHs=
[Contract Exit] mint would overflow supply
 [Success]: ✔ should not mint tokens if new total supply overflows RTrace: +210
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAo=
 [Success]: ✔ should transfer tokens RTrace: +335
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] from has not authorized transfer
 [Success]: ✔ should not transfer tokens without the proper authorizations RTrace: +182
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] cannot transfer to yourself
 [Success]: ✔ should not transfer tokens to self RTrace: +180
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] account 'from' has insufficient balance
 [Success]: ✔ should not transfer if insufficient balance RTrace: +210
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EGQ=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAE=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAE=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAE=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAE=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAE=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3GAQ=
[Event] koinos.contracts.token.burn_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6EAE=
 [Success]: ✔ should delay effective balance RTrace: +1795
[Event] koinos.contracts.token.mint_event / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] koinos.contracts.token.transfer_event / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAo=
 [Success]: ✔ should transfer tokens without authority RTrace: +338

    [File]: assembly/__tests__/vhp.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 13 pass,  0 fail, 13 total
    [Time]: 389.089ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 1 total
  [Groups]: 2 count, 2 pass
   [Tests]: 13 pass, 0 fail, 13 total
    [Time]: 9600.103ms
┌─────────────────┬───────┬───────┬──────┬──────┬────────────────────────────────────────┐
│ File            │ Total │ Block │ Func │ Expr │ Uncovered                              │
├─────────────────┼───────┼───────┼──────┼──────┼────────────────────────────────────────┤
│ assembly/Vhp.ts │ 92.3% │ 88.4% │ 100% │ 100% │ 138:52, 217:26, 260:12, 311:36, 320:24 │
├─────────────────┼───────┼───────┼──────┼──────┼────────────────────────────────────────┤
│ total           │ 92.3% │ 88.4% │ 100% │ 100% │                                        │
└─────────────────┴───────┴───────┴──────┴──────┴────────────────────────────────────────┘

✨  Done in 10.55s.
```
