### PR TITLE
Bump `sdk-as` to v1.0.2

### DIFF
--- a/contracts/claim/package.json
+++ b/contracts/claim/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@koinos/sdk-as": "1.0.1",
+    "@koinos/sdk-as": "1.0.2",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/contracts/claim/yarn.lock
+++ b/contracts/claim/yarn.lock
@@ -724,10 +724,10 @@
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"@koinos/proto-as@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.2.tgz#87dede9ef870b2089edc34f10e8d855490ed93ba"
-  integrity sha512-0jktc4p/K0oj3/Zx30TGwI38ZnLdtBXFmf7ky/ukhpqvx8GhWhzJwWRyf1e3VDqhEiLNRjyMw+mAMI0VVo1Umg==
+"@koinos/proto-as@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.3.tgz#d8c4d99c8262f0df8dd128a4052e2490d32c7c1f"
+  integrity sha512-kdxWBGZ8weSpO9kD4oviGc/LkAcdCRoBieHn9ciCiom8GyyUAovAUVztb28Hu/FRgHEADrSJjM+u4ekSEWQ/jA==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
@@ -744,10 +744,10 @@
     chalk "4.1.2"
     commander "^9.0.0"
 
-"@koinos/sdk-as@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.1.tgz#448f3a32b9ba274ff58fea213db318f8f790ef0a"
-  integrity sha512-koTIHPdsZZ/OdoBT/byNw99L17uaR6pDRhi774y2znhvj4EJFz/KQfgS2hla0yDwJKKhAoMzr/tf7V1rfyi3BA==
+"@koinos/sdk-as@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.2.tgz#a9b4917aaa0cdf9030db0ab6f330772229d4736d"
+  integrity sha512-W1BcTLfmVQrfn/Jqh1mcA+y8NAXAzKbI8H1J1PMNidpg1fZQlF4rdYe+XwW/yRV18vnkJnjrsMODIu5j7t8WnA==
   dependencies:
     "@as-covers/core" "^0.2.1"
     "@as-pect/cli" "^6.2.4"
@@ -755,7 +755,7 @@
     "@koinos/as-gen" "1.0.0"
     "@koinos/as-proto-gen" "1.0.0"
     "@koinos/mock-vm" "1.0.0"
-    "@koinos/proto-as" "1.0.2"
+    "@koinos/proto-as" "1.0.3"
     "@koinos/sdk-as-cli" "1.0.0"
     "@roamin/protoc" "^2.4.0"
     as-bignum "^0.2.18"

--- a/contracts/governance/package.json
+++ b/contracts/governance/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@koinos/sdk-as": "1.0.1",
+    "@koinos/sdk-as": "1.0.2",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/contracts/governance/yarn.lock
+++ b/contracts/governance/yarn.lock
@@ -724,10 +724,10 @@
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"@koinos/proto-as@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.2.tgz#87dede9ef870b2089edc34f10e8d855490ed93ba"
-  integrity sha512-0jktc4p/K0oj3/Zx30TGwI38ZnLdtBXFmf7ky/ukhpqvx8GhWhzJwWRyf1e3VDqhEiLNRjyMw+mAMI0VVo1Umg==
+"@koinos/proto-as@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.3.tgz#d8c4d99c8262f0df8dd128a4052e2490d32c7c1f"
+  integrity sha512-kdxWBGZ8weSpO9kD4oviGc/LkAcdCRoBieHn9ciCiom8GyyUAovAUVztb28Hu/FRgHEADrSJjM+u4ekSEWQ/jA==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
@@ -744,10 +744,10 @@
     chalk "4.1.2"
     commander "^9.0.0"
 
-"@koinos/sdk-as@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.1.tgz#448f3a32b9ba274ff58fea213db318f8f790ef0a"
-  integrity sha512-koTIHPdsZZ/OdoBT/byNw99L17uaR6pDRhi774y2znhvj4EJFz/KQfgS2hla0yDwJKKhAoMzr/tf7V1rfyi3BA==
+"@koinos/sdk-as@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.2.tgz#a9b4917aaa0cdf9030db0ab6f330772229d4736d"
+  integrity sha512-W1BcTLfmVQrfn/Jqh1mcA+y8NAXAzKbI8H1J1PMNidpg1fZQlF4rdYe+XwW/yRV18vnkJnjrsMODIu5j7t8WnA==
   dependencies:
     "@as-covers/core" "^0.2.1"
     "@as-pect/cli" "^6.2.4"
@@ -755,7 +755,7 @@
     "@koinos/as-gen" "1.0.0"
     "@koinos/as-proto-gen" "1.0.0"
     "@koinos/mock-vm" "1.0.0"
-    "@koinos/proto-as" "1.0.2"
+    "@koinos/proto-as" "1.0.3"
     "@koinos/sdk-as-cli" "1.0.0"
     "@roamin/protoc" "^2.4.0"
     as-bignum "^0.2.18"

--- a/contracts/name_service/package.json
+++ b/contracts/name_service/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@koinos/sdk-as": "1.0.1",
+    "@koinos/sdk-as": "1.0.2",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/contracts/name_service/yarn.lock
+++ b/contracts/name_service/yarn.lock
@@ -724,10 +724,10 @@
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"@koinos/proto-as@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.2.tgz#87dede9ef870b2089edc34f10e8d855490ed93ba"
-  integrity sha512-0jktc4p/K0oj3/Zx30TGwI38ZnLdtBXFmf7ky/ukhpqvx8GhWhzJwWRyf1e3VDqhEiLNRjyMw+mAMI0VVo1Umg==
+"@koinos/proto-as@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.3.tgz#d8c4d99c8262f0df8dd128a4052e2490d32c7c1f"
+  integrity sha512-kdxWBGZ8weSpO9kD4oviGc/LkAcdCRoBieHn9ciCiom8GyyUAovAUVztb28Hu/FRgHEADrSJjM+u4ekSEWQ/jA==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
@@ -744,10 +744,10 @@
     chalk "4.1.2"
     commander "^9.0.0"
 
-"@koinos/sdk-as@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.1.tgz#448f3a32b9ba274ff58fea213db318f8f790ef0a"
-  integrity sha512-koTIHPdsZZ/OdoBT/byNw99L17uaR6pDRhi774y2znhvj4EJFz/KQfgS2hla0yDwJKKhAoMzr/tf7V1rfyi3BA==
+"@koinos/sdk-as@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.2.tgz#a9b4917aaa0cdf9030db0ab6f330772229d4736d"
+  integrity sha512-W1BcTLfmVQrfn/Jqh1mcA+y8NAXAzKbI8H1J1PMNidpg1fZQlF4rdYe+XwW/yRV18vnkJnjrsMODIu5j7t8WnA==
   dependencies:
     "@as-covers/core" "^0.2.1"
     "@as-pect/cli" "^6.2.4"
@@ -755,7 +755,7 @@
     "@koinos/as-gen" "1.0.0"
     "@koinos/as-proto-gen" "1.0.0"
     "@koinos/mock-vm" "1.0.0"
-    "@koinos/proto-as" "1.0.2"
+    "@koinos/proto-as" "1.0.3"
     "@koinos/sdk-as-cli" "1.0.0"
     "@roamin/protoc" "^2.4.0"
     as-bignum "^0.2.18"

--- a/contracts/pob/package.json
+++ b/contracts/pob/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@koinos/sdk-as": "1.0.1",
+    "@koinos/sdk-as": "1.0.2",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/contracts/pob/yarn.lock
+++ b/contracts/pob/yarn.lock
@@ -724,10 +724,10 @@
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"@koinos/proto-as@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.2.tgz#87dede9ef870b2089edc34f10e8d855490ed93ba"
-  integrity sha512-0jktc4p/K0oj3/Zx30TGwI38ZnLdtBXFmf7ky/ukhpqvx8GhWhzJwWRyf1e3VDqhEiLNRjyMw+mAMI0VVo1Umg==
+"@koinos/proto-as@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.3.tgz#d8c4d99c8262f0df8dd128a4052e2490d32c7c1f"
+  integrity sha512-kdxWBGZ8weSpO9kD4oviGc/LkAcdCRoBieHn9ciCiom8GyyUAovAUVztb28Hu/FRgHEADrSJjM+u4ekSEWQ/jA==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
@@ -744,10 +744,10 @@
     chalk "4.1.2"
     commander "^9.0.0"
 
-"@koinos/sdk-as@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.1.tgz#448f3a32b9ba274ff58fea213db318f8f790ef0a"
-  integrity sha512-koTIHPdsZZ/OdoBT/byNw99L17uaR6pDRhi774y2znhvj4EJFz/KQfgS2hla0yDwJKKhAoMzr/tf7V1rfyi3BA==
+"@koinos/sdk-as@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.2.tgz#a9b4917aaa0cdf9030db0ab6f330772229d4736d"
+  integrity sha512-W1BcTLfmVQrfn/Jqh1mcA+y8NAXAzKbI8H1J1PMNidpg1fZQlF4rdYe+XwW/yRV18vnkJnjrsMODIu5j7t8WnA==
   dependencies:
     "@as-covers/core" "^0.2.1"
     "@as-pect/cli" "^6.2.4"
@@ -755,7 +755,7 @@
     "@koinos/as-gen" "1.0.0"
     "@koinos/as-proto-gen" "1.0.0"
     "@koinos/mock-vm" "1.0.0"
-    "@koinos/proto-as" "1.0.2"
+    "@koinos/proto-as" "1.0.3"
     "@koinos/sdk-as-cli" "1.0.0"
     "@roamin/protoc" "^2.4.0"
     as-bignum "^0.2.18"

--- a/contracts/vhp/package.json
+++ b/contracts/vhp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "devDependencies": {
-    "@koinos/sdk-as": "1.0.1",
+    "@koinos/sdk-as": "1.0.2",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",

--- a/contracts/vhp/yarn.lock
+++ b/contracts/vhp/yarn.lock
@@ -724,10 +724,10 @@
     protobufjs "^6.11.2"
     somap "^0.5.14"
 
-"@koinos/proto-as@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.2.tgz#87dede9ef870b2089edc34f10e8d855490ed93ba"
-  integrity sha512-0jktc4p/K0oj3/Zx30TGwI38ZnLdtBXFmf7ky/ukhpqvx8GhWhzJwWRyf1e3VDqhEiLNRjyMw+mAMI0VVo1Umg==
+"@koinos/proto-as@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@koinos/proto-as/-/proto-as-1.0.3.tgz#d8c4d99c8262f0df8dd128a4052e2490d32c7c1f"
+  integrity sha512-kdxWBGZ8weSpO9kD4oviGc/LkAcdCRoBieHn9ciCiom8GyyUAovAUVztb28Hu/FRgHEADrSJjM+u4ekSEWQ/jA==
   dependencies:
     as-proto "npm:@koinos/as-proto"
 
@@ -744,10 +744,10 @@
     chalk "4.1.2"
     commander "^9.0.0"
 
-"@koinos/sdk-as@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.1.tgz#448f3a32b9ba274ff58fea213db318f8f790ef0a"
-  integrity sha512-koTIHPdsZZ/OdoBT/byNw99L17uaR6pDRhi774y2znhvj4EJFz/KQfgS2hla0yDwJKKhAoMzr/tf7V1rfyi3BA==
+"@koinos/sdk-as@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@koinos/sdk-as/-/sdk-as-1.0.2.tgz#a9b4917aaa0cdf9030db0ab6f330772229d4736d"
+  integrity sha512-W1BcTLfmVQrfn/Jqh1mcA+y8NAXAzKbI8H1J1PMNidpg1fZQlF4rdYe+XwW/yRV18vnkJnjrsMODIu5j7t8WnA==
   dependencies:
     "@as-covers/core" "^0.2.1"
     "@as-pect/cli" "^6.2.4"
@@ -755,7 +755,7 @@
     "@koinos/as-gen" "1.0.0"
     "@koinos/as-proto-gen" "1.0.0"
     "@koinos/mock-vm" "1.0.0"
-    "@koinos/proto-as" "1.0.2"
+    "@koinos/proto-as" "1.0.3"
     "@koinos/sdk-as-cli" "1.0.0"
     "@roamin/protoc" "^2.4.0"
     as-bignum "^0.2.18"


### PR DESCRIPTION
Resolves #94

## Brief description

Bump `sdk-as` to v1.0.2

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
